### PR TITLE
fixed 'ghost' image issue

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -8,7 +8,7 @@ import queryTrendingImg from "./scripts/queryTrendingImg";
 import filterImgRating from "./scripts/filterImgRating";
 
 
-const apiKey = "ebk9TgbXWDj65HhL7XZbexSaBR4XYyQJ"
+const apiKey = "7zXTZYA3auJeCtontYTUMLwB1uAN9On3"
 
 
 

--- a/src/components/ImageTable.js
+++ b/src/components/ImageTable.js
@@ -11,7 +11,8 @@ export default function ImageTable(props){
             {props.imgArr === [] ? <p style={{color: "white"}}>empty</p> : 
             <div className="row">
                     <div className="column">
-                        {props.imgArr.map((data) => <ImageCell key={data['id']} className="gif" data={data}/>)}
+                        {props.imgArr.map((data) => <ImageCell key={data['id'] + Math.floor(Math.random() * (999999999 - 0 + 1)) + 0} className="gif" data={data}/>)}
+                        {/* random to avoid id confliction, better solution is to filter out the repeated images when fetching from api */}
                     </div>
             </div>
             }

--- a/src/scripts/sortImgSize.js
+++ b/src/scripts/sortImgSize.js
@@ -1,4 +1,4 @@
-// maybe not to embed the function
+// maybe not to embedded the function
 
 export default function sortImgSize(imgArr, setImgArr){
     setImgArr(imgArr.sort(compare))


### PR DESCRIPTION
The issue was one of the images was repeated in trending-api, so it makes the array image has two images with same key(id), When mapping image table, dom renders both images but only removes 1 when re-render